### PR TITLE
like cloc()work

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,8 @@ Authors@R: c(
            comment = c(ORCID = "0000-0001-5670-2640")),
     person("Al", "Danial", comment = "cloc perl script", role=c("aut")),
     person("Maëlle", "Salmon", email = "maelle.salmon@yahoo.se", role = c("ctb")), 
-    person("Chris", "Muir", email = "chrismuirrva@gmail.com", role = c("ctb"))
+    person("Chris", "Muir", email = "chrismuirrva@gmail.com", role = c("ctb")),
+    person("Mark", "Padgham", email = "mark.padgham@email.com", role = c("ctb"))
   )
 Description: Counts blank lines, comment lines, and physical lines of source code 
     in source files/trees/archives. An R wrapper to the 'Perl' command-line utility 

--- a/R/cloc.R
+++ b/R/cloc.R
@@ -19,7 +19,7 @@
 #' # from a url
 #' cloc("https://rud.is/dl/cloc-1.74.tar.gz")
 #' }
-cloc <- function(source, extract_with = NULL) {
+cloc <- function(source = ".", extract_with = NULL) {
 
   perl <- Sys.which("perl")
 

--- a/man/cloc.Rd
+++ b/man/cloc.Rd
@@ -4,7 +4,7 @@
 \alias{cloc}
 \title{Count lines of code, comments and whitespace in source files/archives}
 \usage{
-cloc(source, extract_with = NULL)
+cloc(source = ".", extract_with = NULL)
 }
 \arguments{
 \item{source}{file, directory or archive to read from (can be a valid URL)}


### PR DESCRIPTION
Thanks @hrbrmstr - i was just about to embark on a package to do this meself when ... there y'are already! This PR makes this work:
```
cloc()
```
whereas previously required at least
```
cloc(".")
```
There's also a new version available (1.77) if you wanna merge your `inst/bin`, but i'll leave that up to you.