### PR TITLE
add additional check to get perl path from Sys.getenv()

### DIFF
--- a/R/cloc-recognized-languages.r
+++ b/R/cloc-recognized-languages.r
@@ -27,14 +27,7 @@
 #' cloc_recognized_languages()
 cloc_recognized_languages <- function() {
 
-  perl <- Sys.which("perl")
-
-  if (perl == "") {
-    stop(
-      "Cannot find 'perl'. cloc requires perl to be installed and on the PATH.",
-      call. = FALSE
-    )
-  }
+  perl <- find_perl()
 
   c(
     system.file("bin/cloc.pl", package = "cloc"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,10 +10,17 @@ find_perl <- function() {
   perl <- Sys.which("perl")
 
   if (perl == "") {
-    stop(
-      "Cannot find 'perl'. cloc requires perl to be installed and on the PATH.",
-      call. = FALSE
-    )
+
+    try({perl <- Sys.getenv()[['perl']]}, silent = TRUE)
+
+    if (perl == "") {
+      stop(
+        "Cannot find 'perl'. cloc requires perl to be installed and on the PATH.\n",
+        "       Or add an entry to .Renviron file like perl='/path/to/perl.exe'.",
+        call. = FALSE
+      )
+    }
+
   }
 
   return(perl)


### PR DESCRIPTION
I am currently working on a windows machine and was only able to install the portable version of perl into my user directory. So `Sys.which()` was not able to locate perl. This PR adds an additional check of the .Reviron for a perl variable. This will allow users to manually add the installed location of perl when `Sys.which()` fails.

thanks